### PR TITLE
Update the rule percentage to 0.2% instead of 1%

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = [
-    "> 1%",
+    "> 0.2%",
     "not dead",
     "not ie <= 11",
     "not op_mini all"


### PR DESCRIPTION
The why:
A good chunk of the userbase of Apricot is currently using browsers that are excluded by the `1%` rule (like Chrome < 96).
We estimate that this impacts about 22% of our clients.
With the `0.2%` rule, we should reduce that impact to below 5%.

We want to match the logic of redirecting users to an "unsupported browser" page to the one behind the browserslist we use.