### PR TITLE
Allowing all browsers that have been released in the past year

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = [
-    "last 1 year or > 0.2%",
+    "last 1 year",
+    "> 0.2%",
     "not dead",
     "not ie <= 11",
     "not op_mini all"

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = [
-    "> 0.2%",
+    "last 1 year or > 0.2%",
     "not dead",
     "not ie <= 11",
     "not op_mini all"


### PR DESCRIPTION
Allowing all browsers that have been released in the past year instead of simply looking at the usage of said browsers.

We had two support requests for ShareGate Management where users got blacklisted while using a browser version that had been released 5 months ago (Edge 103) and 2 months ago (Firefox 102.1.0).

Here's the reach of the current browserlist rule: https://browsersl.ist/#q=%3E+0.2%25%2C+not+dead%2C+not+ie+%3C%3D+11%2C+not+op_mini+all

Here's how this PR would affect that reach:
https://browsersl.ist/#q=last+1+year+or+%3E+0.2%25%2C+not+dead%2C+not+ie+%3C%3D+11%2C+not+op_mini+all