### PR TITLE
Remove redundant IE 11 exclusion, and add Firefox ESR

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,5 @@ module.exports = [
     "last 1 year",
     "> 0.2%",
     "not dead",
-    "not ie <= 11",
     "not op_mini all"
 ];

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = [
     "last 1 year",
     "> 0.2%",
+    "Firefox ESR",
     "not dead",
     "not op_mini all"
 ];


### PR DESCRIPTION
IE11 is now considered dead: 
https://browsersl.ist/#q=dead

Firefox ESR should be included with the last 1 year, but should be added just to be sure